### PR TITLE
Messed up PATH setting 

### DIFF
--- a/rails_bootcamp_setup.haml
+++ b/rails_bootcamp_setup.haml
@@ -70,12 +70,12 @@
 
               > curl -s https://toolbelt.heroku.com/install.sh | sh  
               > PATH="/usr/local/heroku/bin:$PATH"  
-              > echo 'PATH="/usr/local/heroku/bin:$PATH"'  
+              > echo 'PATH="/usr/local/heroku/bin:$PATH"' >> ~/.profile 
 
               zsh users need to run the command below: (if you don't know what
               it is you aren't using it)
 
-              > echo 'PATH="/usr/local/heroku/bin:$PATH"' >> ~/.profile 
+              > echo 'PATH="/usr/local/heroku/bin:$PATH"' >> ~/.zprofile 
 
               This requires root/admin on the machine you're working on. If you
               don't have it, instead

--- a/rails_bootcamp_setup.html
+++ b/rails_bootcamp_setup.html
@@ -82,14 +82,14 @@
             <blockquote>
             <p>curl -s https://toolbelt.heroku.com/install.sh | sh<br>
             PATH=&quot;/usr/local/heroku/bin:$PATH&quot;<br>
-            echo &#39;PATH=&quot;/usr/local/heroku/bin:$PATH&quot;&#39;  </p>
+            echo &#39;PATH=&quot;/usr/local/heroku/bin:$PATH&quot;&#39; &gt;&gt; ~/.profile </p>
             </blockquote>
             
             <p>zsh users need to run the command below: (if you don&#39;t know what
             it is you aren&#39;t using it)</p>
             
             <blockquote>
-            <p>echo &#39;PATH=&quot;/usr/local/heroku/bin:$PATH&quot;&#39; &gt;&gt; ~/.profile </p>
+            <p>echo &#39;PATH=&quot;/usr/local/heroku/bin:$PATH&quot;&#39; &gt;&gt; ~/.zprofile </p>
             </blockquote>
             
             <p>This requires root/admin on the machine you&#39;re working on. If you


### PR DESCRIPTION
This commit makes the instructions correctly add the new PATH to either .profile or .zprofile, for zsh and other shells. I got mixed up when writing the part about .zsh since I had to look into it while I was editing, and with the current instructions the line isn't added to .profile or added to .profile for zsh users that need it in .zprofile. I've reviewed the rest of the instructions and they should be good.
